### PR TITLE
feat: add colorful frame buffer support to kernel.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,8 +38,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
+name = "mikanos-rs-frame-buffer"
+version = "0.1.0"
+dependencies = [
+ "uefi",
+]
+
+[[package]]
 name = "mikanos-rs-kernel"
 version = "0.1.0"
+dependencies = [
+ "mikanos-rs-frame-buffer",
+]
 
 [[package]]
 name = "mikanos-rs-loader"
@@ -47,6 +57,7 @@ version = "0.1.0"
 dependencies = [
  "goblin",
  "log",
+ "mikanos-rs-frame-buffer",
  "uefi",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,4 +3,5 @@
 members = [
   "mikanos-rs-loader",
   "mikanos-rs-kernel",
+  "mikanos-rs-frame-buffer",
 ]

--- a/mikanos-rs-frame-buffer/Cargo.toml
+++ b/mikanos-rs-frame-buffer/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "mikanos-rs-frame-buffer"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+uefi = "0.33.0"

--- a/mikanos-rs-frame-buffer/src/lib.rs
+++ b/mikanos-rs-frame-buffer/src/lib.rs
@@ -1,0 +1,75 @@
+#![no_std]
+
+use core::slice;
+use uefi::proto::console::gop::{GraphicsOutput, PixelFormat};
+
+pub struct PixelColor {
+    r: u8,
+    g: u8,
+    b: u8,
+}
+
+impl PixelColor {
+    pub fn new(r: u8, g: u8, b: u8) -> Self {
+        Self { r, g, b }
+    }
+}
+
+#[repr(C)]
+pub struct FrameBuffer {
+    frame_buffer: *mut u8,
+    pixels_per_scanline: usize,
+    horizontal_resolution: usize,
+    vertical_resolution: usize,
+    pixel_format: PixelFormat,
+}
+
+impl FrameBuffer {
+    pub fn new(gop: &mut GraphicsOutput) -> Self {
+        let (horizontal, vertical) = gop.current_mode_info().resolution();
+        let pixel_format = gop.current_mode_info().pixel_format();
+
+        Self {
+            frame_buffer: gop.frame_buffer().as_mut_ptr(),
+            pixels_per_scanline: gop.current_mode_info().stride(),
+            horizontal_resolution: horizontal,
+            vertical_resolution: vertical,
+            pixel_format,
+        }
+    }
+
+    pub fn size(&self) -> usize {
+        4 * self.pixels_per_scanline * self.vertical_resolution
+    }
+
+    fn as_slice_mut(&self) -> &'static mut [u8] {
+        unsafe { slice::from_raw_parts_mut(self.frame_buffer, self.size()) }
+    }
+
+    pub fn write_pixel(&self, pos_x: usize, pos_y: usize, c: &PixelColor) {
+        let pixel_idx = self.pixels_per_scanline * pos_y + pos_x;
+        let pixel_format = self.pixel_format;
+        let p = self.as_slice_mut();
+        match pixel_format {
+            PixelFormat::Rgb => {
+                p[4 * pixel_idx] = c.r;
+                p[4 * pixel_idx + 1] = c.g;
+                p[4 * pixel_idx + 2] = c.b;
+            }
+            PixelFormat::Bgr => {
+                p[4 * pixel_idx] = c.b;
+                p[4 * pixel_idx + 1] = c.g;
+                p[4 * pixel_idx + 2] = c.r;
+            }
+            _ => unimplemented!(),
+        }
+    }
+
+    pub fn fill(&self, color: &PixelColor) {
+        for x in 0..self.horizontal_resolution {
+            for y in 0..self.vertical_resolution {
+                self.write_pixel(x, y, color)
+            }
+        }
+    }
+}

--- a/mikanos-rs-kernel/Cargo.toml
+++ b/mikanos-rs-kernel/Cargo.toml
@@ -4,3 +4,4 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+mikanos-rs-frame-buffer = { path = "../mikanos-rs-frame-buffer" }

--- a/mikanos-rs-kernel/src/main.rs
+++ b/mikanos-rs-kernel/src/main.rs
@@ -2,7 +2,7 @@
 #![no_main]
 
 use core::panic::PanicInfo;
-use core::slice;
+use mikanos_rs_frame_buffer::{FrameBuffer, PixelColor};
 
 #[panic_handler]
 fn panic(_info: &PanicInfo) -> ! {
@@ -10,15 +10,15 @@ fn panic(_info: &PanicInfo) -> ! {
 }
 
 #[unsafe(no_mangle)]
-pub extern "C" fn kernel_main(frame_buffer_base: *mut u8, frame_buffer_size: usize) {
-    let mut cnt = 0;
-    loop {
-        let buf = unsafe { slice::from_raw_parts_mut(frame_buffer_base, frame_buffer_size) };
-        if cnt % 2 == 0 {
-            buf.fill(0);
-        } else {
-            buf.fill(255);
+pub extern "C" fn kernel_main(frame_buffer: FrameBuffer) {
+    frame_buffer.fill(&PixelColor::new(255, 255, 255));
+    let rect_width = 200;
+    let rect_height = 100;
+    let offset = (100, 100);
+    for x in 0..rect_width {
+        for y in 0..rect_height {
+            frame_buffer.write_pixel(x + offset.0, y + offset.1, &PixelColor::new(0, 255, 0));
         }
-        cnt += 1;
     }
+    loop {}
 }

--- a/mikanos-rs-loader/Cargo.toml
+++ b/mikanos-rs-loader/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2024"
 log = "0.4.22"
 goblin = { version = "0.9.2", features = ["elf64", "elf32", "endian_fd"], default-features = false}
 uefi = { version = "0.33.0", features = ["panic_handler", "logger", "alloc", "global_allocator"] }
+mikanos-rs-frame-buffer = { path = "../mikanos-rs-frame-buffer" }

--- a/mikanos-rs-loader/src/main.rs
+++ b/mikanos-rs-loader/src/main.rs
@@ -17,6 +17,8 @@ use uefi::proto::media::file::{
 };
 use uefi::proto::media::fs::SimpleFileSystem;
 
+use mikanos_rs_frame_buffer::FrameBuffer;
+
 fn open_root_dir() -> uefi::Result<Directory> {
     let loaded_image = boot::open_protocol_exclusive::<LoadedImage>(boot::image_handle())?;
     let device_handle = loaded_image.device().expect("Device handle should exist.");
@@ -99,7 +101,7 @@ fn load_elf(elf_data: &[u8]) -> elf::Elf {
     prog
 }
 
-type EntryPoint = extern "sysv64" fn(*mut u8, usize);
+type EntryPoint = extern "sysv64" fn(FrameBuffer);
 fn load_kernel(kernel_file: &mut RegularFile) -> uefi::Result<EntryPoint> {
     let buf = read_file(kernel_file)?;
     info!("Read kernel file: size={}", buf.len());
@@ -162,8 +164,7 @@ fn main() -> Status {
     save_memory_map(memmap_file).expect("Failed to save memory map.");
 
     let mut gop = open_gop().expect("Failed to open gop.");
-    let frame_buffer_base = gop.frame_buffer().as_mut_ptr();
-    let frame_buffer_size = gop.frame_buffer().size();
+    let frame_buffer = FrameBuffer::new(&mut gop);
     log_gop_info(&mut gop);
 
     let mut kernel_file = root_dir
@@ -182,7 +183,7 @@ fn main() -> Status {
     // Is it correct to use LOADER_DATA type here?
     let _ = unsafe { boot::exit_boot_services(boot::MemoryType::LOADER_DATA) };
 
-    entry(frame_buffer_base, frame_buffer_size);
+    entry(frame_buffer);
 
     info!("All done.");
     boot::stall(10_000_000);


### PR DESCRIPTION
osbook_day04b

- Introduce `mikanos-rs-frame-buffer` crate for frame buffer operations.
- Update `Cargo.toml` and `Cargo.lock` to include the new crate.
- Modify `kernel_main` to use `FrameBuffer` for pixel manipulation.
- Update `mikanos-rs-loader` to pass `FrameBuffer` to the kernel.