### PR TITLE
Add support for interrupt handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,6 +15,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc827186963e592360843fb5ba4b973e145841266c1357f7180c43526f2e5b61"
 
 [[package]]
+name = "bitfield"
+version = "0.19.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62a3a774b2fcac1b726922b921ebba5e9fe36ad37659c822cf8ff2c1e0819892"
+dependencies = [
+ "bitfield-macros",
+]
+
+[[package]]
+name = "bitfield-macros"
+version = "0.19.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52511b09931f7d5fe3a14f23adefbc23e5725b184013e96c8419febb61f14734"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -94,6 +114,7 @@ dependencies = [
 name = "mikanos-rs-kernel"
 version = "0.1.0"
 dependencies = [
+ "bitfield",
  "cc",
  "glob",
  "lazy_static",
@@ -122,9 +143,9 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.92"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
+checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
 dependencies = [
  "unicode-ident",
 ]
@@ -187,7 +208,7 @@ checksum = "7f81c2fde025af7e69b1d1420531c8a8811ca898919db177141a85313b1cb932"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.94",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -224,9 +245,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.94"
+version = "2.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "987bc0be1cdea8b10216bd06e2ca407d40b9543468fafd3ddfb02f36e77f71f3"
+checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -277,7 +298,7 @@ checksum = "9b24e77d3fc1e617051e630f99da24bcae6328abab37b8f9216bb68d06804f9a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.94",
+ "syn 2.0.106",
 ]
 
 [[package]]

--- a/mikanos-rs-kernel/Cargo.toml
+++ b/mikanos-rs-kernel/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+bitfield = "0.19.2"
 mikanos-rs-frame-buffer = { path = "../mikanos-rs-frame-buffer" }
 uefi = { version = "0.33.0", default-features = false }
 lazy_static = { version = "1.0", features = ["spin_no_std"] }

--- a/mikanos-rs-kernel/src/interrupt.rs
+++ b/mikanos-rs-kernel/src/interrupt.rs
@@ -1,4 +1,161 @@
 use crate::xhci::get_xhc;
+use bitfield::bitfield;
+
+#[repr(u8)]
+pub enum InterruptVector {
+    XHCI = 0x40,
+}
+
+#[repr(u16)]
+pub enum DescriptorType {
+    InterruptGate = 14,
+}
+
+bitfield! {
+  #[repr(transparent)]
+  #[derive(Clone, Copy)]
+  pub struct IDTAttribute(u16);
+  pub interrupt_stack_table, _ : 2, 0;
+  // padding : 7, 3;
+  pub r#type, set_type : 11, 8;
+  // padding : 12;
+  pub descriptor_privilege_level, set_descriptor_privilege_level : 14, 13;
+  pub present, set_present : 15;
+}
+
+impl IDTAttribute {
+    #[inline]
+    pub const fn empty() -> Self {
+        Self(0)
+    }
+    #[inline]
+    pub fn new(descriptor_type: DescriptorType, descriptor_privilege_level: u16) -> Self {
+        let mut attr = Self(0);
+        // Assume IST (interrupt stack table) value is 0.
+        attr.set_type(descriptor_type as u16);
+        attr.set_descriptor_privilege_level(descriptor_privilege_level);
+        attr.set_present(true);
+        attr
+    }
+}
+
+#[derive(Clone, Copy)]
+#[repr(C)]
+struct InterruptDescriptor {
+    offset_low: u16,
+    segment_selector: u16,
+    attr: IDTAttribute,
+    offset_middle: u16,
+    offset_high: u32,
+    _reserved: u32,
+}
+
+impl InterruptDescriptor {
+    #[inline]
+    pub const fn empty() -> Self {
+        Self {
+            offset_low: 0,
+            segment_selector: 0,
+            attr: IDTAttribute::empty(),
+            offset_middle: 0,
+            offset_high: 0,
+            _reserved: 0,
+        }
+    }
+    #[inline]
+    pub fn new(attr: IDTAttribute, offset: u64) -> Self {
+        let mut cs: u16 = 0;
+        // Get the current value of the code-segment register.
+        unsafe { core::arch::asm!("mov ax, cs", out("ax") cs) }
+        Self {
+            offset_low: (offset & 0xffff) as u16,
+            segment_selector: cs,
+            attr,
+            offset_middle: ((offset & 0xffff0000) >> 16) as u16,
+            offset_high: (offset >> 32) as u32,
+            _reserved: 0,
+        }
+    }
+}
+
+#[repr(C, packed(2))]
+struct DescriptorTablePointer {
+    limit: u16,
+    base: u64,
+}
+
+impl DescriptorTablePointer {
+    pub fn new(limit: u16, base: u64) -> Self {
+        Self { limit, base }
+    }
+    pub fn get_base(&self) -> u64 {
+        self.base
+    }
+    pub fn get_limit(&self) -> u16 {
+        self.limit
+    }
+    pub fn from_current_idt() -> Self {
+        let mut descriptor_pointer = Self::new(0, 0);
+        unsafe {
+            core::arch::asm!("sidt [{}]", in(reg) &mut descriptor_pointer);
+        }
+        descriptor_pointer
+    }
+}
+
+#[repr(align(16))]
+struct InterruptDescriptorTable {
+    data: [InterruptDescriptor; 256],
+}
+
+impl InterruptDescriptorTable {
+    const TABLE_SIZE: usize = 256;
+    #[inline]
+    pub const fn new() -> Self {
+        Self {
+            data: [InterruptDescriptor::empty(); Self::TABLE_SIZE],
+        }
+    }
+    pub fn set_entry(&mut self, idx: usize, entry: InterruptDescriptor) {
+        self.data[idx] = entry;
+    }
+    fn get_limit(&self) -> u16 {
+        (Self::TABLE_SIZE * core::mem::size_of::<InterruptDescriptor>() - 1) as u16
+    }
+    #[inline]
+    fn to_descriptor_pointer(&self) -> DescriptorTablePointer {
+        let limit = self.get_limit();
+        DescriptorTablePointer::new(limit, self as *const Self as u64)
+    }
+    pub unsafe fn load(&self) {
+        let descriptor_pointer = self.to_descriptor_pointer();
+        core::arch::asm!("lidt [{}]", in(reg) &descriptor_pointer);
+    }
+}
+
+pub type HandlerFunc = extern "x86-interrupt" fn();
+
+static mut IDT: InterruptDescriptorTable = InterruptDescriptorTable::new();
+
+pub fn init_idt() {
+    unsafe {
+        IDT.set_entry(
+            InterruptVector::XHCI as usize,
+            InterruptDescriptor::new(
+                IDTAttribute::new(DescriptorType::InterruptGate, 0),
+                handle_xhci_event as u64,
+            ),
+        );
+        IDT.load();
+    }
+    // Check IDT configuration
+    let current_idtp = DescriptorTablePointer::from_current_idt();
+    let idt_base = unsafe { &IDT as *const InterruptDescriptorTable as u64 };
+    let limit = unsafe { IDT.get_limit() };
+    assert_eq!(current_idtp.get_base(), idt_base);
+    assert_eq!(current_idtp.get_limit(), limit);
+    crate::serial_print!("IDT initialization done.")
+}
 
 fn notify_end_of_interrupt() {
     let eoi_reg = 0xfee000b0 as *mut u32;

--- a/mikanos-rs-kernel/src/interrupt.rs
+++ b/mikanos-rs-kernel/src/interrupt.rs
@@ -1,0 +1,11 @@
+use crate::xhci::get_xhc;
+
+fn notify_end_of_interrupt() {
+    let eoi_reg = 0xfee000b0 as *mut u32;
+    unsafe { *eoi_reg = 0 };
+}
+
+pub extern "x86-interrupt" fn handle_xhci_event() {
+    get_xhc().lock().process_event();
+    notify_end_of_interrupt();
+}

--- a/mikanos-rs-kernel/src/interrupt.rs
+++ b/mikanos-rs-kernel/src/interrupt.rs
@@ -173,6 +173,13 @@ pub fn init_idt() {
     crate::serial_print!("IDT initialization done.")
 }
 
+#[inline]
+pub fn enable_maskable_interrupts() {
+    unsafe {
+        core::arch::asm!("sti");
+    }
+}
+
 fn notify_end_of_interrupt() {
     let eoi_reg = 0xfee000b0 as *mut u32;
     unsafe { *eoi_reg = 0 };

--- a/mikanos-rs-kernel/src/main.rs
+++ b/mikanos-rs-kernel/src/main.rs
@@ -9,6 +9,7 @@ mod serial;
 mod xhci;
 
 use core::panic::PanicInfo;
+use interrupt::enable_maskable_interrupts;
 use mikanos_rs_frame_buffer::{FrameBuffer, PixelColor};
 use mouse::{MouseEvent, init_mouse};
 use uefi::mem::memory_map::{MemoryMap, MemoryMapOwned};
@@ -186,6 +187,9 @@ pub extern "C" fn kernel_main_new_stack(
     for i in 1..=16 {
         get_xhc().lock().configure_port(i);
     }
+
+    // Start responding hardware interrupts.
+    enable_maskable_interrupts();
 
     serial_println!("Checking for a xhc event...");
     loop {}

--- a/mikanos-rs-kernel/src/main.rs
+++ b/mikanos-rs-kernel/src/main.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
 #![feature(abi_x86_interrupt)]
-
+#[allow(static_mut_refs)]
 mod interrupt;
 mod mouse;
 mod pci;
@@ -127,6 +127,8 @@ pub extern "C" fn kernel_main_new_stack(
     frame_buffer: &'static FrameBuffer,
     memory_map: &'static MemoryMapOwned,
 ) {
+    interrupt::init_idt();
+
     frame_buffer.fill(&PixelColor::new(255, 255, 255));
 
     let mut console = Console::new(

--- a/mikanos-rs-kernel/src/xhci.rs
+++ b/mikanos-rs-kernel/src/xhci.rs
@@ -89,6 +89,17 @@ impl Controller {
     }
 }
 
+static XHC: spin::Once<spin::Mutex<&'static mut Controller>> = spin::Once::new();
+
+pub fn init_xhc(mmio_base: u64) {
+    XHC.call_once(|| spin::Mutex::new(Controller::new(mmio_base)));
+    get_xhc().lock().init();
+}
+
+pub fn get_xhc() -> &'static spin::Mutex<&'static mut Controller> {
+    XHC.get().unwrap()
+}
+
 pub fn initialize_mouse() {
     unsafe { set_default_mouse_observer(crate::mouse::observer) };
 }

--- a/run.sh
+++ b/run.sh
@@ -21,6 +21,6 @@ qemu-system-x86_64 \
   -drive if=pflash,format=raw,readonly=on,file=assets/OVMF_CODE.fd \
   -drive if=pflash,format=raw,readonly=on,file=assets/OVMF_VARS.fd \
   -drive format=raw,file=fat:rw:esp \
-  -device qemu-xhci \
+  -device nec-usb-xhci,id=xhci \
   -device usb-mouse \
   -device usb-kbd


### PR DESCRIPTION
This PR adds interrupt handling support:

- Configure the interrupt descriptor table (IDT).
- Add interrupt and exception handlers:
  - Zero division error (0x00)
  - Double fault (0x08)
  - xHCI (0x40)
- Enable hardware maskable interrupts.
- Configure MSI for xHCI controller
- Change USB device
  - `qemu-xhci` does not support MSI.