### PR TITLE
feat: Add interrupt guard

### DIFF
--- a/mikanos-rs-kernel/src/event.rs
+++ b/mikanos-rs-kernel/src/event.rs
@@ -1,5 +1,7 @@
 use crate::queue::Queue;
 
+use crate::interrupt::InterruptGuard;
+
 #[derive(Clone, Copy)]
 pub enum Event {
     Invalid = 0,
@@ -13,5 +15,15 @@ impl Default for Event {
 }
 
 const QUEUE_SIZE: usize = 32;
-pub static EVENT_QUEUE: spin::Mutex<Queue<Event, QUEUE_SIZE>> =
+static mut EVENT_QUEUE: spin::Mutex<Queue<Event, QUEUE_SIZE>> =
     spin::Mutex::new(Queue::<Event, QUEUE_SIZE>::new(Event::Invalid));
+
+#[allow(static_mut_refs)]
+pub fn get_event_queue() -> InterruptGuard<spin::Mutex<Queue<Event, QUEUE_SIZE>>> {
+    unsafe { InterruptGuard::new(&mut EVENT_QUEUE) }
+}
+
+#[allow(static_mut_refs)]
+pub unsafe fn get_event_queue_raw() -> &'static spin::Mutex<Queue<Event, QUEUE_SIZE>> {
+    &EVENT_QUEUE
+}

--- a/mikanos-rs-kernel/src/interrupt.rs
+++ b/mikanos-rs-kernel/src/interrupt.rs
@@ -187,6 +187,36 @@ pub fn disable_maskable_interrupts() {
     }
 }
 
+pub struct InterruptGuard<T> {
+    ptr: *mut T,
+}
+
+impl<T> InterruptGuard<T> {
+    pub fn new(val: &mut T) -> Self {
+        disable_maskable_interrupts();
+        Self { ptr: val as *mut T }
+    }
+}
+
+impl<T> Drop for InterruptGuard<T> {
+    fn drop(&mut self) {
+        enable_maskable_interrupts();
+    }
+}
+
+impl<T> core::ops::Deref for InterruptGuard<T> {
+    type Target = T;
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*self.ptr }
+    }
+}
+
+impl<T> core::ops::DerefMut for InterruptGuard<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        unsafe { &mut *self.ptr }
+    }
+}
+
 fn notify_end_of_interrupt() {
     let eoi_reg = 0xfee000b0 as *mut u32;
     unsafe { *eoi_reg = 0 };
@@ -204,7 +234,7 @@ pub extern "x86-interrupt" fn handle_double_fault() {
 
 pub extern "x86-interrupt" fn handle_xhci_event() {
     use crate::event::Event;
-    if let Err(_event) = crate::event::EVENT_QUEUE.lock().push(Event::XHCI) {
+    if let Err(_event) = unsafe { crate::event::get_event_queue_raw().lock().push(Event::XHCI) } {
         crate::serial_println!("Warning: EVENT_QUEUE full, XHCI event dropped");
     }
     notify_end_of_interrupt();

--- a/mikanos-rs-kernel/src/main.rs
+++ b/mikanos-rs-kernel/src/main.rs
@@ -196,14 +196,10 @@ pub extern "C" fn kernel_main_new_stack(
     serial_println!("Checking for a xhc event...");
     // main event loop
     loop {
-        disable_maskable_interrupts();
-        if event::EVENT_QUEUE.lock().is_empty() {
-            enable_maskable_interrupts();
+        if event::get_event_queue().lock().is_empty() {
             continue;
         }
-        disable_maskable_interrupts();
-        let event = event::EVENT_QUEUE.lock().pop().unwrap();
-        enable_maskable_interrupts();
+        let event = event::get_event_queue().lock().pop().unwrap();
 
         match event {
             event::Event::XHCI => {


### PR DESCRIPTION
`struct InterruptGuard` を導入し、割り込みの無効化/有効化を `InterruptGuard` 変数の生存区間に応じて自動的に行うようにした。