### PR TITLE
feat: Add bitmap memory manager.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,6 +88,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "linked_list_allocator"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afa463f5405ee81cdb9cc2baf37e08ec7e4c8209442b5d72c04cfb2cd6e6286"
+dependencies = [
+ "spinning_top",
+]
+
+[[package]]
 name = "lock_api"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -118,6 +127,7 @@ dependencies = [
  "cc",
  "glob",
  "lazy_static",
+ "linked_list_allocator",
  "mikanos-rs-frame-buffer",
  "spin 0.10.0",
  "uart_16550",
@@ -228,6 +238,15 @@ name = "spin"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
+name = "spinning_top"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b9eb1a2f4c41445a3a0ff9abc5221c5fcd28e1f13cd7c0397706f9ac938ddb0"
 dependencies = [
  "lock_api",
 ]

--- a/mikanos-rs-kernel/.cargo/config.toml
+++ b/mikanos-rs-kernel/.cargo/config.toml
@@ -3,4 +3,4 @@ target = "./x86_64-mikanos_rs.json"
 
 [unstable]
 build-std-features = ["compiler-builtins-mem"]
-build-std = ["core", "compiler_builtins"]
+build-std = ["core", "alloc", "compiler_builtins"]

--- a/mikanos-rs-kernel/Cargo.toml
+++ b/mikanos-rs-kernel/Cargo.toml
@@ -11,6 +11,7 @@ lazy_static = { version = "1.0", features = ["spin_no_std"] }
 spin = "0.10.0"
 uart_16550 = "0.2.0"
 x86_64 = "0.14.2"
+linked_list_allocator = "0.10.5"
 
 [build-dependencies]
 cc = "1.2.29"

--- a/mikanos-rs-kernel/src/allocator.rs
+++ b/mikanos-rs-kernel/src/allocator.rs
@@ -1,0 +1,19 @@
+use linked_list_allocator::LockedHeap;
+
+#[global_allocator]
+static ALLOCATOR: LockedHeap = LockedHeap::empty();
+
+const HEAP_SIZE: usize = 128 * 1024 * 1024; // 128 MB
+const NUM_HEAP_PAGES: usize = HEAP_SIZE / crate::memory_manager::PAGE_SIZE;
+
+pub fn init_heap() {
+    let heap_start = crate::memory_manager::MEMORY_MANAGER
+        .lock()
+        .allocate(NUM_HEAP_PAGES)
+        .unwrap()
+        .get_addr() as *mut u8;
+    unsafe {
+        ALLOCATOR.lock().init(heap_start, HEAP_SIZE);
+    }
+    crate::serial_println!("Init heap done.");
+}

--- a/mikanos-rs-kernel/src/main.rs
+++ b/mikanos-rs-kernel/src/main.rs
@@ -1,6 +1,9 @@
 #![no_std]
 #![no_main]
 #![feature(abi_x86_interrupt)]
+extern crate alloc;
+
+mod allocator;
 mod descriptor;
 mod event;
 #[allow(static_mut_refs)]
@@ -138,6 +141,7 @@ pub extern "C" fn kernel_main_new_stack(
     paging::setup_identity_page_table();
     interrupt::init_idt();
     memory_manager::init(memory_map);
+    allocator::init_heap();
 
     frame_buffer.fill(&PixelColor::new(255, 255, 255));
 
@@ -149,10 +153,8 @@ pub extern "C" fn kernel_main_new_stack(
 
     for _ in 0..4 {
         for i in 0..10 {
-            let mut format_str: [u8; 256] = [0; 256];
-            (&mut format_str[0..13]).copy_from_slice("? HelloWorld\n".as_bytes());
-            format_str[0] = b'0' + i;
-            console.put_string(core::str::from_utf8(&format_str[0..13]).unwrap());
+            let s = alloc::format!("{} HelloWorld\n", i);
+            console.put_string(&s);
         }
     }
 
@@ -219,20 +221,6 @@ pub extern "C" fn kernel_main_new_stack(
                 panic!()
             }
         }
-    }
-
-    let header = "Index, Type, Type(name), PhysicalStart, NumberOfPages, Attribute";
-    serial_println!("{}", header);
-    for (i, desc) in memory_map.entries().enumerate() {
-        serial_println!(
-            "{}, {:#x}, {:?}, {:#08x}, {}, {:#x}",
-            i,
-            desc.ty.0,
-            desc.ty,
-            desc.phys_start,
-            desc.page_count,
-            desc.att.bits() & 0xfffff,
-        );
     }
     loop {}
 }

--- a/run.sh
+++ b/run.sh
@@ -17,6 +17,7 @@ cp target/x86_64-mikanos_rs/debug/mikanos-rs-kernel esp/kernel.elf
 
 # Launch VM
 qemu-system-x86_64 \
+  -m 1G \
   -serial stdio \
   -drive if=pflash,format=raw,readonly=on,file=assets/OVMF_CODE.fd \
   -drive if=pflash,format=raw,readonly=on,file=assets/OVMF_VARS.fd \


### PR DESCRIPTION
This pull request introduces dynamic memory allocation to the kernel by a bitmap-based physical memory manager and a heap allocator.

**Physical page frame management:**

* Introduced a new `memory_manager` module (`mikanos-rs-kernel/src/memory_manager.rs`) implementing a bitmap-based physical memory manager, and initialization from the UEFI memory map. 

**Heap allocator (linked_list_allocator):**

* Enable the `alloc` crate.
  * Compilation setting in `.cargo/config.toml`.
  * Add `extern crate alloc` in `main.rs`.
* Added a new `allocator` module (`mikanos-rs-kernel/src/allocator.rs`) that sets up a global heap allocator using `LockedHeap` from the `linked_list_allocator` crate, allocates a 128MB heap.

**QEMU configuration:**

* Increased the QEMU VM memory allocation to 1GB in `run.sh` to support the larger heap.

**Other minor changes:**

* Updated a console printing to use heap-allocated strings via `alloc::format!` instead of fixed-size buffers, demonstrating dynamic memory allocation.
* Removed memory map debug output from the kernel main function, as it is no longer used.