### PR TITLE
fix: Fix/Suppress most of warnings.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,4 @@ members = [
   "mikanos-rs-kernel",
   "mikanos-rs-frame-buffer",
 ]
+resolver = "3"

--- a/mikanos-rs-kernel/src/event.rs
+++ b/mikanos-rs-kernel/src/event.rs
@@ -25,5 +25,5 @@ pub fn get_event_queue() -> InterruptGuard<spin::Mutex<Queue<Event, QUEUE_SIZE>>
 
 #[allow(static_mut_refs)]
 pub unsafe fn get_event_queue_raw() -> &'static spin::Mutex<Queue<Event, QUEUE_SIZE>> {
-    &EVENT_QUEUE
+    unsafe { &EVENT_QUEUE }
 }

--- a/mikanos-rs-kernel/src/main.rs
+++ b/mikanos-rs-kernel/src/main.rs
@@ -18,10 +18,10 @@ mod serial;
 mod xhci;
 
 use core::panic::PanicInfo;
-use interrupt::{disable_maskable_interrupts, enable_maskable_interrupts};
+use interrupt::enable_maskable_interrupts;
 use mikanos_rs_frame_buffer::{FrameBuffer, PixelColor};
 use mouse::{MouseEvent, init_mouse};
-use uefi::mem::memory_map::{MemoryMap, MemoryMapOwned};
+use uefi::mem::memory_map::MemoryMapOwned;
 use xhci::{get_xhc, init_xhc};
 
 #[panic_handler]
@@ -181,7 +181,9 @@ pub extern "C" fn kernel_main_new_stack(
     let msg_data = 0xc000 | (interrupt::InterruptVector::XHCI as u32);
     crate::serial_println!("msg_addr: {:x}", msg_addr);
     crate::serial_println!("msg_data: {:x}", msg_data);
-    let msi_cap_ptr = xhci_controller_addr.configure_msi(msg_addr, msg_data);
+    xhci_controller_addr
+        .configure_msi(msg_addr, msg_data)
+        .unwrap();
 
     // Initialize USB driver
     let mmio_base = xhci_controller_addr.read_bar_64(0).unwrap();
@@ -222,5 +224,4 @@ pub extern "C" fn kernel_main_new_stack(
             }
         }
     }
-    loop {}
 }

--- a/mikanos-rs-kernel/src/memory_manager.rs
+++ b/mikanos-rs-kernel/src/memory_manager.rs
@@ -60,6 +60,7 @@ impl BitmapMemoryManager {
             start_frame_id = start_frame_id.offset(i + 1)
         }
     }
+    #[allow(unused)]
     pub fn free(&mut self, start_frame: FrameID, num_frames: usize) {
         assert!(self.is_initialized);
         assert!(
@@ -103,7 +104,7 @@ pub static MEMORY_MANAGER: spin::Mutex<BitmapMemoryManager> =
 
 pub fn init(memory_map: &'static MemoryMapOwned) {
     let mut available_end = 0;
-    for (i, desc) in memory_map.entries().enumerate() {
+    for desc in memory_map.entries() {
         if available_end < desc.phys_start {
             let start_frame_id = FrameID((available_end / PAGE_SIZE as u64) as usize);
             let num_pages = ((desc.phys_start - available_end) / PAGE_SIZE as u64) as usize;

--- a/mikanos-rs-kernel/src/mouse.rs
+++ b/mikanos-rs-kernel/src/mouse.rs
@@ -1,7 +1,7 @@
 use mikanos_rs_frame_buffer::{FrameBuffer, PixelColor};
 
 pub struct MouseEvent {
-    buttons: u8,
+    _buttons: u8,
     displacement_x: i8,
     displacement_y: i8,
 }
@@ -9,7 +9,7 @@ pub struct MouseEvent {
 impl MouseEvent {
     pub fn new(buttons: u8, displacement_x: i8, displacement_y: i8) -> Self {
         Self {
-            buttons,
+            _buttons: buttons,
             displacement_x,
             displacement_y,
         }

--- a/mikanos-rs-kernel/src/pci.rs
+++ b/mikanos-rs-kernel/src/pci.rs
@@ -237,7 +237,6 @@ impl PCIAddress {
         msi_cap.message_addr = msg_addr;
         msi_cap.message_data = msg_data;
         self.write_msi_cap(cap_ptr, msi_cap);
-        let msi_cap_new = self.read_msi_cap(cap_ptr);
         Some(())
     }
     pub fn read_bar_64(&self, idx: u8) -> Option<u64> {

--- a/mikanos-rs-kernel/src/segment.rs
+++ b/mikanos-rs-kernel/src/segment.rs
@@ -91,7 +91,9 @@ impl GlobalDescriptorTable {
     }
     unsafe fn load(&self) {
         let descriptor_pointer = self.to_descriptor_pointer();
-        core::arch::asm!("lgdt [{}]", in(reg) &descriptor_pointer);
+        unsafe {
+            core::arch::asm!("lgdt [{}]", in(reg) &descriptor_pointer);
+        }
     }
 }
 


### PR DESCRIPTION
- HandlerFunc の型 alias を利用して Interrupt descriptor の型を明確にする。
- Cargo virtual workspace の resolver version を指定する。
  - ref. https://doc.rust-lang.org/cargo/reference/resolver.html#resolver-versions
- Warning の抑制
  - `MouseEvent` で現状使っていない `buttons` を `_` prefix にする。
  - `BitmapMemoryManager::free()` は使っていないが、実装としては残しておく。
- 使われていない `use` を消す
- 未使用変数, dead code を消す
- `unsafe` を明示する