### PR TITLE
wip: wake up main task when event queue is not empty.

### DIFF
--- a/mikanos-rs-kernel/src/task.rs
+++ b/mikanos-rs-kernel/src/task.rs
@@ -218,6 +218,9 @@ impl TaskPool {
         self.get_task_idx(task_id)
             .map(|task_idx| self.tasks[task_idx].set_status(TaskStatus::Running))
     }
+    fn get_current_task_idx(&self) -> TaskID {
+        self.tasks[self.current_task_idx].id
+    }
 }
 
 static mut TASK_POOL: core::cell::OnceCell<TaskPool> = core::cell::OnceCell::new();
@@ -376,4 +379,9 @@ pub fn wake_up_task(task_id: &TaskID) {
     unsafe {
         TASK_POOL.get_mut().unwrap().wake_up(task_id);
     }
+}
+
+#[allow(static_mut_refs)]
+pub fn this_task() -> TaskID {
+    unsafe { TASK_POOL.get().unwrap().get_current_task_idx() }
 }


### PR DESCRIPTION
現状をメモする。

OSを起動後、しばらくマウスやキー入力を続けていると、突然それらのイベントが処理されなくなっているように見える。しかし、Task B, C は動き続けているためデッドロックは起きていない。デバッガを接続しても有益な情報は得られていない。