### PR TITLE
fix: Prevent deadlocks for a serial console.

### DIFF
--- a/mikanos-rs-kernel/src/serial.rs
+++ b/mikanos-rs-kernel/src/serial.rs
@@ -12,10 +12,12 @@ lazy_static! {
 
 pub fn _print(args: ::core::fmt::Arguments) {
     use core::fmt::Write;
-    SERIAL1
-        .lock()
-        .write_fmt(args)
-        .expect("Printing to serial failed");
+    x86_64::instructions::interrupts::without_interrupts(|| {
+        SERIAL1
+            .lock()
+            .write_fmt(args)
+            .expect("Printing to serial failed");
+    });
 }
 
 /// Prints to the host through the serial interface.


### PR DESCRIPTION
fix #73
